### PR TITLE
Add script/docker-test for testing with different distros

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+/.git
+/docker
+/fixture
+/script
+/target
+/tests
+/tmp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+## Getting Started
+
+In order to work on this project, you'll need to install a few things:
+
+1. A recent version of [Rust](https://www.rustup.rs/) (CI runs against the latest stable, beta, and nightly).
+1. [Docker](https://www.docker.com/) (only required to if you need/want to run a manual test...please do!).
+
+Unit tests are in a local `mod test` in each file. If an integration test is warranted, please add a new test to the
+_tests_ directory.
+
+Be sure to only test the public interface. (Not trying to start a war, just picked a side already and don't want to hash
+it out again).
+
+To run your tests, just run `cargo test --all`.
+
+## Manual Testing
+
+After making any significant change, it's a good idea to run a test. To make this easier, there's a script you can run
+to compile a release build of `dfiler` and load it up within a docker container.
+
+The script is `script/docker-test`. The basic usage is:
+
+`script/docker-test <distro> [SOURCE=./fixture/source]`
+
+This will fire up a docker container with the built binary on the PATH, and `$2` mounted in `~/dotfiles`. You can then
+run a test with `dfiler -s ./dotfiles`.
+
+## Submitting a PR
+
+Here are some general guidelines for making PRs for this repo.
+
+1. [Fork this repo](https://github.com/pseudomuto/dfiler/fork)
+1. Make a branch off of master (`git checkout -b <your_branch_name>`)
+1. Make focused commits with descriptive messages
+1. Add tests that fail without your code, and pass with it
+1. RustFmt your code! (I've got vim setup to `cargo fmt` on save)
+1. **Ping someone on the PR** (Lots of people, including myself, won't get a notification unless pinged directly)
+
+Every PR should have a well detailed summary of the changes being made and the reasoning behind them. Make sure to add
+at least three sections.
+
+### What is Changing?
+
+Make sure you spell out in as much detail as necessary what will happen to which systems when your PR is merged, 
+what are the expected changes.
+
+### How is it Changing?
+
+Include any relevant implementation details, mimize surprises for the reviewers in this section, if you had to take some 
+unorthodox approaches (read hacks), explain why here.
+
+### What Could Go Wrong?
+
+How has this change been tested? In your opinion what is the risk, if any, of merging these changes.
+
+#### Reviewers should:
+
+1. Identify anything that the PR author may have missed from above.
+2. Test the PR through whatever means necessary, including manually, to verify it is safe to be deployed.
+3. Question everything. Never assume that something was tested or fully understood, always question and ask if there is
+any uncertainty.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 [![Build Status](https://travis-ci.org/pseudomuto/dfiler.svg?branch=master)](https://travis-ci.org/pseudomuto/dfiler)
 
 A tool for managing dotfiles and packages for 'nix systems. Very much a WIP...
+
+This is still early stages, but if you're interested in taking it for a whirl, check out
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docker/Dockerfile.jessie
+++ b/docker/Dockerfile.jessie
@@ -1,0 +1,31 @@
+################################################################################
+# Stage 0: Build the binary
+################################################################################
+FROM rust:jessie as builder
+MAINTAINER <david.muto@gmail.com>
+WORKDIR /usr/src/dfiler
+
+COPY . .
+RUN cargo build --bin dfiler --release
+
+################################################################################
+# Stage 1: A container to test within
+################################################################################
+FROM debian:jessie-slim
+MAINTAINER <david.muto@gmail.com>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update all the things
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends sudo && \
+  rm -rf /var/lib/apt/lists/*
+
+# Create the test user (password: pAssword1, generated with `openssl passwd -crypt`)
+RUN useradd -m -p QRL2jyE8G9J/E tester && \
+  usermod -aG sudo tester
+
+USER tester
+WORKDIR /home/tester
+COPY --from=builder /usr/src/dfiler/target/release/dfiler /usr/local/bin
+ENTRYPOINT ["bash"]

--- a/docker/Dockerfile.stretch
+++ b/docker/Dockerfile.stretch
@@ -1,0 +1,31 @@
+################################################################################
+# Stage 0: Build the binary
+################################################################################
+FROM rust:stretch as builder
+MAINTAINER <david.muto@gmail.com>
+WORKDIR /usr/src/dfiler
+
+COPY . .
+RUN cargo build --bin dfiler --release
+
+################################################################################
+# Stage 1: A container to test within
+################################################################################
+FROM debian:stretch-slim
+MAINTAINER <david.muto@gmail.com>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update all the things
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends sudo && \
+  rm -rf /var/lib/apt/lists/*
+
+# Create the test user (password: pAssword1, generated with `openssl passwd -crypt`)
+RUN useradd -m -p QRL2jyE8G9J/E tester && \
+  usermod -aG sudo tester
+
+USER tester
+WORKDIR /home/tester
+COPY --from=builder /usr/src/dfiler/target/release/dfiler /usr/local/bin
+ENTRYPOINT ["bash"]

--- a/script/docker-test
+++ b/script/docker-test
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# Creates a release build for the specified distro, and shoves it into a docker container. The dfiler executable will be
+# on the PATH, so you can run it from within the container with `dfiler [OPTIONS]`
+#
+# Usage:
+#   * script/docker-test <distro> [SOURCE=$(pwd)/fixture/source]
+#
+# This container will be build and run interatively. It'll have $2 volume mounted to ~/dotfiles as read only. The
+# typical test case is to run `script/docker-test <os>` and from within the container run `dfiler -s dotfiles`.
+#
+# Available distros:
+#   * stretch - Runs stretch slim
+#   * jessie - Runs jessie slim
+
+main() {
+  local dfiler_dir="${2:-$(pwd)/fixture/source}"
+  echo "Mounting ${dfiler_dir}"
+
+  docker build -f docker/Dockerfile.$1 -t dfiler/$1 .
+  docker run --rm -it -v "${dfiler_dir}:/home/tester/dotfiles:ro" dfiler/$1
+}
+
+main "$@"


### PR DESCRIPTION
After making any significant change, it's a good idea to run a test. To make this easier, I've added a script you can run to compile a release build of `dfiler` and load it up within a docker container.

The script is `script/docker-test`. The basic usage is:

`script/docker-test <distro> [SOURCE=./fixture/source]`

This will fire up a docker container with the built binary on the PATH, and `$2` mounted in `~/dotfiles`. You can then run a test with `dfiler -s ./dotfiles`.