### PR TITLE
Add task.RunTaskList

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,7 @@ project_name: dfiler
 
 before:
   hooks:
-    - make sync
+    - go mod tidy
 
 builds:
   - main: ./cmd/dfiler

--- a/pkg/tasks/BUILD.bazel
+++ b/pkg/tasks/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "run.go",
         "symlink.go",
         "task.go",
     ],
@@ -24,6 +25,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "mock_fs_test.go",
+        "run_test.go",
         "symlink_test.go",
         "task_test.go",
     ],

--- a/pkg/tasks/run.go
+++ b/pkg/tasks/run.go
@@ -1,0 +1,58 @@
+package tasks
+
+type RunOptions struct {
+	DryRun  bool
+	Undo    bool
+	Before  func(t Task) error
+	After   func(t Task, err error) error
+	NoTasks func()
+}
+
+func RunTaskList(tl *TaskList, opts RunOptions) error {
+	tasks := tl.PendingTasks()
+	if opts.Undo {
+		tasks = tl.CompletedTasks()
+	}
+
+	if len(tasks) == 0 {
+		if opts.NoTasks != nil {
+			opts.NoTasks()
+		}
+
+		return nil
+	}
+
+	for _, t := range tasks {
+		if err := runTask(t, &opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func runTask(t Task, opts *RunOptions) error {
+	if opts.Before != nil {
+		if err := opts.Before(t); err != nil {
+			return err
+		}
+	}
+
+	fn := t.Do
+	if opts.Undo {
+		fn = t.Undo
+	}
+
+	var err error
+	if !opts.DryRun {
+		err = fn()
+	}
+
+	if opts.After != nil {
+		if err := opts.After(t, err); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/tasks/run_test.go
+++ b/pkg/tasks/run_test.go
@@ -1,0 +1,126 @@
+package tasks_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/pseudomuto/dfiler/pkg/tasks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunTaskList(t *testing.T) {
+	tests := []struct {
+		name    string
+		tasks   TaskList
+		opts    *testOptions
+		wantErr error
+	}{
+		{
+			name: "no tasks",
+			opts: newTestOptions(1, 0, 0, nil, nil, false),
+		},
+		{
+			name: "some tasks",
+			tasks: TaskList{
+				Tasks: []Task{
+					&testTask{done: true},
+					&testTask{},
+					&testTask{done: true},
+				},
+			},
+			opts: newTestOptions(0, 1, 1, nil, nil, false),
+		},
+		{
+			name: "some tasks to undo",
+			tasks: TaskList{
+				Tasks: []Task{
+					&testTask{done: true},
+					&testTask{},
+					&testTask{done: true},
+				},
+			},
+			opts: newTestOptions(0, 2, 2, nil, nil, true),
+		},
+		{
+			name: "before errors",
+			tasks: TaskList{
+				Tasks: []Task{&testTask{}},
+			},
+			opts:    newTestOptions(0, 1, 0, errors.New("BeforeBoom"), nil, false),
+			wantErr: errors.New("BeforeBoom"),
+		},
+		{
+			name: "after errors",
+			tasks: TaskList{
+				Tasks: []Task{&testTask{}},
+			},
+			opts:    newTestOptions(0, 1, 1, nil, errors.New("AfterBoom"), false),
+			wantErr: errors.New("AfterBoom"),
+		},
+		{
+			name: "do errors",
+			tasks: TaskList{
+				Tasks: []Task{&testTask{do: errors.New("DoBoom")}},
+			},
+			opts:    newTestOptions(0, 1, 1, nil, nil, false),
+			wantErr: errors.New("DoBoom"),
+		},
+		{
+			name: "undo errors",
+			tasks: TaskList{
+				Tasks: []Task{&testTask{done: true, undo: errors.New("UndoBoom")}},
+			},
+			opts:    newTestOptions(0, 1, 1, nil, nil, true),
+			wantErr: errors.New("UndoBoom"),
+		},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.wantErr, RunTaskList(&tt.tasks, tt.opts.runOpts), tt.name)
+
+		require.Equal(t, tt.opts.emptyCount, tt.opts.expEmptyCount, tt.name)
+		require.Equal(t, tt.opts.beforeCount, tt.opts.expBeforeCount, tt.name)
+		require.Equal(t, tt.opts.afterCount, tt.opts.expAfterCount, tt.name)
+	}
+}
+
+type testOptions struct {
+	emptyCount     int
+	expEmptyCount  int
+	beforeCount    int
+	beforeErr      error
+	expBeforeCount int
+	afterCount     int
+	afterErr       error
+	expAfterCount  int
+	runOpts        RunOptions
+}
+
+func newTestOptions(ec, bc, ac int, be error, ae error, undo bool) *testOptions {
+	opts := &testOptions{
+		expEmptyCount:  ec,
+		expBeforeCount: bc,
+		expAfterCount:  ac,
+		beforeErr:      be,
+		afterErr:       ae,
+	}
+
+	opts.runOpts = RunOptions{
+		Undo:    undo,
+		NoTasks: func() { opts.emptyCount++ },
+		Before: func(t Task) error {
+			opts.beforeCount++
+			return opts.beforeErr
+		},
+		After: func(t Task, err error) error {
+			opts.afterCount++
+			if err != nil {
+				return err
+			}
+
+			return opts.afterErr
+		},
+	}
+
+	return opts
+}

--- a/pkg/tasks/symlink.go
+++ b/pkg/tasks/symlink.go
@@ -57,7 +57,11 @@ func (s *symlink) Do() error {
 }
 
 func (s *symlink) Undo() error {
-	return s.fs.Remove(s.link)
+	if s.IsDone() {
+		return s.fs.Remove(s.link)
+	}
+
+	return nil
 }
 
 func (s *symlink) IsDone() bool {

--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -59,3 +59,17 @@ func (tl *TaskList) PendingTasks() []Task {
 
 	return tasks
 }
+
+// CompletedTasks returns only tasks where IsDone returns true
+func (tl *TaskList) CompletedTasks() []Task {
+	tasks := []Task{}
+	for _, t := range tl.Tasks {
+		if !t.IsDone() {
+			continue
+		}
+
+		tasks = append(tasks, t)
+	}
+
+	return tasks
+}

--- a/pkg/tasks/task_test.go
+++ b/pkg/tasks/task_test.go
@@ -138,6 +138,19 @@ func TestTaskListPendingTasks(t *testing.T) {
 	require.Len(t, list.PendingTasks(), 1)
 }
 
+func TestTaskListCompletedTasks(t *testing.T) {
+	list := TaskList{
+		Name: "test list",
+		Tasks: []Task{
+			&testTask{done: true},
+			&testTask{},
+			&testTask{done: true},
+		},
+	}
+
+	require.Len(t, list.CompletedTasks(), 2)
+}
+
 type testTask struct {
 	do   error
 	undo error

--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -11,16 +11,18 @@ import (
 var (
 	cyan   = ""
 	green  = ""
-	yellow = ""
+	red    = ""
 	reset  = ""
+	yellow = ""
 )
 
 func init() {
 	trm := term.NewTerminal(nil, "")
 	cyan = string(trm.Escape.Cyan)
 	green = string(trm.Escape.Green)
-	yellow = string(trm.Escape.Yellow)
+	red = string(trm.Escape.Red)
 	reset = string(trm.Escape.Reset)
+	yellow = string(trm.Escape.Yellow)
 }
 
 func Cyan(str string) string {
@@ -29,6 +31,10 @@ func Cyan(str string) string {
 
 func Green(str string) string {
 	return color(str, green)
+}
+
+func Red(str string) string {
+	return color(str, red)
 }
 
 func Yellow(str string) string {


### PR DESCRIPTION
Adding support for running tasks lists via task.RunTaskList. While this
could be accomplished by a simple for loop using list.PendingTasks(), I
think it will make adding a global `-undo` flag easier.